### PR TITLE
Fetch xpub from Coko, with https

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -21,8 +21,9 @@ elife-xpub-repository:
 
 xpub-repository:
     builder.git_latest:
-        - name: git@github.com:elifesciences/xpub.git
-        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - name: https://gitlab.coko.foundation/yld/xpub.git 
+        #- name: git@github.com:elifesciences/xpub.git
+        #- identity: {{ pillar.elife.projects_builder.key or '' }}
         - rev: master
         - branch: master
         - target: /srv/xpub/


### PR DESCRIPTION
Since this is the repository that gets progressively deployed on testing and production environments, it should bring with itself a reproducible commit as a dependency