### PR TITLE
Trying to always restart the service

### DIFF
--- a/salt/elife-xpub/config/lib-systemd-system-xpub.service
+++ b/salt/elife-xpub/config/lib-systemd-system-xpub.service
@@ -12,5 +12,5 @@ User={{ pillar.elife.deploy_user.username }}
 Environment="INK_USERNAME={{ pillar.elife_xpub.ink.user }}"
 Environment="INK_PASSWORD={{ pillar.elife_xpub.ink.password }}"
 Environment="INK_ENDPOINT={{ pillar.elife_xpub.ink.endpoint }}"
-ExecStart=/usr/bin/npm start --prefix=packages/xpub-collabra/
+ExecStart=/usr/bin/npm somethingelsestart --prefix=packages/xpub-collabra/
 Restart=on-failure

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -77,9 +77,11 @@ xpub-service:
         - require:
             - xpub-configuration
 
-    cmd.run:
-        # always restart, don't trust
-        - name: systemctl restart xpub
+    service.running:
+        # how to always restart?
+        - name: xpub
+        - enable: True
+        - reload: True
         - require:
             - file: xpub-service
 


### PR DESCRIPTION
The `cmd.run` current version restarts the service, but doesn't pick up changes to the `.service` file:
```
[INFO    ] {'pid': 30186, 'retcode': 0, 'stderr': "Warning: xpub.service changed on disk. Run 'systemctl daemon-reload' to reload units.", 
'stdout': ''}
```

I tried to switch to the standard `service.running`, but the `reload` is ignored. What's the correct way to do it?

I read about [ExecReload](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecReload=) for example. Or there may be a way to force `service.running` to restart.