### PR TITLE
Move database setup to script

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -38,6 +38,7 @@ elife-xpub-database-startup:
 elife-xpub-database-creation:
     cmd.script:
         - name: salt://elife-xpub/scripts/create-database.sh
+        - template: jinja
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - require:

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -36,14 +36,10 @@ elife-xpub-database-startup:
             - elife-xpub-environment-variables-for-configuration
 
 elife-xpub-database-creation:
-    cmd.run:
-        - name: docker-compose run app /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; npx pubsweet setupdb --username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
+    cmd.script:
+        - name: salt://elife-xpub/scripts/create-database.sh
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
-        - unless:
-            # cannot use docker-compose run here: it will change the permissions of the volume /var/lib/postgresql/data to 777
-            # for some reason perhaps related to sharing a volume between containers?
-            - docker-compose exec postgres psql xpub xpub -c "SELECT 'public.entities'::regclass"
         - require:
             - elife-xpub-database-startup
 

--- a/salt/elife-xpub/scripts/create-database.sh
+++ b/salt/elife-xpub/scripts/create-database.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ! docker-compose exec -T /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; postgres psql xpub xpub -c \"SELECT 'public.entities'::regclass\""; then
+if ! docker-compose exec -T postgres /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; psql xpub xpub -c \"SELECT 'public.entities'::regclass\""; then
     docker-compose run app /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; npx pubsweet setupdb --username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 fi
 

--- a/salt/elife-xpub/scripts/create-database.sh
+++ b/salt/elife-xpub/scripts/create-database.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+if ! docker-compose exec -T postgres psql xpub xpub -c "SELECT 'public.entities'::regclass"; then
+    docker-compose run app /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; npx pubsweet setupdb --username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
+fi
+

--- a/salt/elife-xpub/scripts/create-database.sh
+++ b/salt/elife-xpub/scripts/create-database.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ! docker-compose exec -T postgres psql xpub xpub -c "SELECT 'public.entities'::regclass"; then
+if ! docker-compose exec -T /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; postgres psql xpub xpub -c \"SELECT 'public.entities'::regclass\""; then
     docker-compose run app /bin/bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done; npx pubsweet setupdb --username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 fi
 


### PR DESCRIPTION
Salt's `onlyif` doesn't show any error or output from the executed command. In this case it was failing due to the lack of `-T` and there was no way to even know.