### PR TITLE
Turn off proxy_buffering on websockets

### DIFF
--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -21,6 +21,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
+        proxy_buffering off;
     }
 
     location / {


### PR DESCRIPTION
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering states this is on by default, and could certainly influence the latency with which notifications can be sent out.