### PR TITLE
Increase maximum upload file size to 100MB

### DIFF
--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -9,7 +9,7 @@ server {
     listen 80;
     {% endif %}
     server_name localhost;
-    client_max_body_size                    "20m";
+    client_max_body_size                    "100m";
 
     location /subscriptions {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Original issue here https://github.com/elifesciences/elife-xpub/issues/595

Why are there quotes around the value? Looking at this it seems that you don't need quotes (e.g. you can use 100m directly) http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size