### PR TITLE
Prune old docker resources on every build

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -71,3 +71,10 @@ elife-xpub-nginx-vhost:
             - elife-xpub-service-ready
         - listen_in:
             - service: nginx-server-service
+
+# frees disk space from old images/containers/volumes/...
+elife-xpub-docker-prune:
+    cmd.run:
+        - name: /usr/local/docker-scripts/docker-prune
+        - require:
+            - docker-ready


### PR DESCRIPTION
Spawned from https://github.com/elifesciences/elife-xpub/issues/613#issuecomment-422364436

Not sure of the performance impact, but if it's done often it may be not as time consuming as once a month.

Executing on a build is more reliable than with a cron, as it will catch all servers that are used even if they are turned off most of the time like `elife-xpub--ci`.