### PR TITLE
Provision AWS credentials from pillars on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This repository should be structured as any Saltstack formula should, but it
 should also conform to the structure required by the [builder](https://github.com/elifesciences/builder) 
 project.
 
-See the eLife [builder example project](https://github.com/elifesciences/builder-example-project)
-for a reference on how to integrate with the `builder` project.
+The project that this formula actually deploys is called [elife-xpub-deployment](https://github.com/elifesciences/elife-xpub-deployment) and has a `docker-compose` configuration targeting a Docker image of `elife-xpub`.
 
 [MIT licensed](LICENCE.txt)

--- a/salt/example.top
+++ b/salt/example.top
@@ -4,5 +4,6 @@ base:
         - elife.external-volume
         - elife.docker
         - elife.nginx
+        - elife.aws-cli
         - elife.aws-credentials
         - elife-xpub

--- a/salt/example.top
+++ b/salt/example.top
@@ -4,4 +4,5 @@ base:
         - elife.external-volume
         - elife.docker
         - elife.nginx
+        - elife.aws-credentials
         - elife-xpub

--- a/salt/pillar/elife-xpub.sls
+++ b/salt/pillar/elife-xpub.sls
@@ -14,3 +14,8 @@ elife_xpub:
         client_secret: fake_client_secret
     pubsweet:
         base_url: fake_pubsweet_baseurl
+
+elife:
+    aws:
+        access_key_id: AKIAFAKE
+        secret_access_key: fake


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/622

This makes a `~/.aws/credentials` file appear for several users (see https://github.com/elifesciences/builder-base-formula/blob/master/elife/aws-credentials.sls).

This file can then be mounted into containers, the [AWS SDKs will read it automatically](https://aws.amazon.com/sdk-for-node-js/).

The credentials stored in this repository will only be used in Vagrant, and are not real. The real ones are stored in https://github.com/elifesciences/builder-private/pull/239 which is private.