### PR TITLE
Disable proxy_request_buffering to allow upload progress to work.

### DIFF
--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -29,6 +29,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass http://app_server;
+        proxy_request_buffering off;
     }
 
     access_log /var/log/nginx/xpub.access.log combined_with_time;


### PR DESCRIPTION
If `proxy_request_buffering` is not disabled nginx will buffer the entire content of the file upload and pass it to the app rapidly. This means the upload progress is not useful as all the messages arrive  at the end of the upload