### PR TITLE
S3_BUCKET variable for elife-xpub

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -28,6 +28,7 @@ elife-xpub-environment-variables-for-configuration:
             export ORCID_CLIENT_ID={{ pillar.elife_xpub.orcid.client_id }}
             export ORCID_CLIENT_SECRET={{ pillar.elife_xpub.orcid.client_secret }}
             export PUBSWEET_BASEURL={{ pillar.elife_xpub.pubsweet.base_url }}
+            export S3_BUCKET={{ pillar.elife_xpub.s3.bucket }}
 
 elife-xpub-database-startup:
     cmd.run:

--- a/salt/pillar/elife-xpub.sls
+++ b/salt/pillar/elife-xpub.sls
@@ -14,6 +14,8 @@ elife_xpub:
         client_secret: fake_client_secret
     pubsweet:
         base_url: fake_pubsweet_baseurl
+    s3:
+        bucket: fake_bucket
 
 elife:
     aws:


### PR DESCRIPTION
Related to https://github.com/elifesciences/elife-xpub/issues/616

Allows us to set a different bucket for demo and production environments.