### PR TITLE
Add PUBSWEET_SECRET for authentication flow

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -38,6 +38,7 @@ elife-xpub-environment-variables-for-configuration:
             export ORCID_CLIENT_ID={{ pillar.elife_xpub.orcid.client_id }}
             export ORCID_CLIENT_SECRET={{ pillar.elife_xpub.orcid.client_secret }}
             export PUBSWEET_BASEURL={{ pillar.elife_xpub.pubsweet.base_url }}
+            export PUBSWEET_SECRET={{ pillar.elife_xpub.pubsweet.secret }}
             export S3_BUCKET={{ pillar.elife_xpub.s3.bucket }}
             export NODE_CONFIG_ENV={{ pillar.elife_xpub.deployment_target }}
 

--- a/salt/pillar/elife-xpub.sls
+++ b/salt/pillar/elife-xpub.sls
@@ -14,6 +14,7 @@ elife_xpub:
         client_secret: fake_client_secret
     pubsweet:
         base_url: fake_pubsweet_baseurl
+        secret: fake_pubsweet_secret
     s3:
         bucket: fake_bucket
     deployment_target: test


### PR DESCRIPTION
`builder-private` values are already in place.

[`PUBSWEET_SECRET` is passed to the container](https://github.com/elifesciences/elife-xpub-deployment/blob/develop/docker-compose.yml#L36) already.