### PR TITLE
Auto-remove container that waits for database

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -89,7 +89,7 @@ elife-xpub-database-available:
     cmd.run:
         - name: |
             # NOTE: var expansion happens on the host not in the container
-            {{ docker_compose }} run app /bin/bash -c "timeout 10 bash -c 'until echo > /dev/tcp/${PGHOST}/${PGPORT} ; do sleep 1 ;done' "
+            {{ docker_compose }} run --rm app /bin/bash -c "timeout 10 bash -c 'until echo > /dev/tcp/${PGHOST}/${PGPORT} ; do sleep 1 ;done' "
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - require:


### PR DESCRIPTION
Otherwise it gets restarted on reboots. Not sure if this is a good solution or will work at all, I am testing it now. Alternatives are to use a separate container image like `bash` or try to `docker-compose exec` in an existing container.