### PR TITLE
Autoremove database setup containers

### DIFF
--- a/salt/elife-xpub/scripts/setup-database.sh
+++ b/salt/elife-xpub/scripts/setup-database.sh
@@ -6,9 +6,9 @@ DB_CREATED_COMMAND="psql -c \"SELECT 'public.entities'::regclass\""
 DB_ENV="-e PGHOST=${PGHOST} -e PGPORT=${PGPORT} -e PGUSER=${PGUSER} -e PGDATABASE=${PGDATABASE} -e PGPASSWORD=${PGPASSWORD}"
 SETUP_ARGS="--username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 
-if ! ${DC_COMMAND} run ${DB_ENV} postgres /bin/bash -c "${DB_CREATED_COMMAND}"
+if ! ${DC_COMMAND} run --rm ${DB_ENV} postgres /bin/bash -c "${DB_CREATED_COMMAND}"
 then
-    ${DC_COMMAND} run app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS}"
+    ${DC_COMMAND} run --rm app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS}"
 else
     echo "Database is already present at ${PGHOST}:${PGPORT}"
 fi


### PR DESCRIPTION
Given the compose services are set to restart, these containers are kept around and create a long list of `xpub_*_run_*` items consuming resources.