### PR TITLE
Support ELB on top of 1 or more nodes

### DIFF
--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -5,9 +5,8 @@ upstream app_server {
 server {
     {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
     listen 443 ssl;
-    {% else %}
-    listen 80;
     {% endif %}
+    listen 80;
     server_name localhost;
     client_max_body_size                    "100m";
 

--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -23,6 +23,12 @@ server {
         proxy_buffering off;
     }
 
+    location /ping {
+        add_header Cache-Control "must-revalidate, no-cache, no-store, private";
+        add_header Content-Type "text/plain; charset=UTF-8";
+        return 200 "pong";
+    }
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -24,6 +24,7 @@ server {
     }
 
     location /ping {
+        # TODO: would be best for the application to implement this
         add_header Cache-Control "must-revalidate, no-cache, no-store, private";
         add_header Content-Type "text/plain; charset=UTF-8";
         return 200 "pong";

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -95,6 +95,7 @@ elife-xpub-database-available:
         - require:
             - elife-xpub-database-startup
 
+{% if salt['elife.cfg']('project.node', 1) == 1 %}
 elife-xpub-database-setup:
     cmd.script:
         - name: salt://elife-xpub/scripts/setup-database.sh
@@ -103,6 +104,9 @@ elife-xpub-database-setup:
         - cwd: /srv/elife-xpub
         - require:
             - elife-xpub-database-available
+        - require_in:
+            - cmd: elife-xpub-docker-compose
+{% endif %}
 
 elife-xpub-docker-compose:
     cmd.run:
@@ -111,7 +115,6 @@ elife-xpub-docker-compose:
         - cwd: /srv/elife-xpub
         - require:
             - elife-xpub-repository
-            - elife-xpub-database-setup
 
 elife-xpub-service-ready:
     cmd.run:


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/770

- Run database setup only from node 1 of a cluster
- Always listen on port 80 too
- Add /ping for health checks