### PR TITLE
Add an Helm chart for deployment on Kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 salt/top.sls
+helm/elife-xpub-*.tgz

--- a/helm/elife-xpub/.helmignore
+++ b/helm/elife-xpub/.helmignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/helm/elife-xpub/Chart.yaml
+++ b/helm/elife-xpub/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart to deploy elife-xpub pull requests on a temporary environment
+name: elife-xpub
+version: 0.1.0

--- a/helm/elife-xpub/templates/NOTES.txt
+++ b/helm/elife-xpub/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Get the application URL by running these commands:
+export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "elife-xpub.fullname" . }})
+# TODO: hardcoded ip of a node can be replaced by a static/dynamic DNS
+export NODE_IP=35.172.178.78
+echo http://$NODE_IP:$NODE_PORT

--- a/helm/elife-xpub/templates/_helpers.tpl
+++ b/helm/elife-xpub/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elife-xpub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elife-xpub.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elife-xpub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/elife-xpub/templates/_helpers.tpl
+++ b/helm/elife-xpub/templates/_helpers.tpl
@@ -12,16 +12,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "elife-xpub.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- default .Release.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: app
-    app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
+        app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
     helm.sh/chart: {{ include "elife-xpub.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
@@ -18,6 +20,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "elife-xpub.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
+    helm.sh/chart: {{ include "elife-xpub.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: NODE_ENV
+            value: production
+          - name: PUBSWEET_SECRET
+            value: example-secret
+          command: ["node", "app"]
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP

--- a/helm/elife-xpub/templates/service.yaml
+++ b/helm/elife-xpub/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elife-xpub.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
+    helm.sh/chart: {{ include "elife-xpub.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: NodePort
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/elife-xpub/templates/service.yaml
+++ b/helm/elife-xpub/templates/service.yaml
@@ -6,6 +6,8 @@ metadata:
     app.kubernetes.io/name: {{ include "elife-xpub.name" . }}
     helm.sh/chart: {{ include "elife-xpub.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: NodePort

--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: xpub/xpub-elife
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""


### PR DESCRIPTION
Experimental chart for deploying a single container. Allows to see the login page.