### PR TITLE
Allow usage of setup-database.sh to clean an environment

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -98,13 +98,20 @@ elife-xpub-database-available:
 
 {% if salt['elife.cfg']('project.node', 1) == 1 %}
 elife-xpub-database-setup:
-    cmd.script:
-        - name: salt://elife-xpub/scripts/setup-database.sh
+    file.managed:
+        - name: /usr/local/bin/setup-database.sh
+        - source: salt://elife-xpub/scripts/setup-database.sh
         - template: jinja
+        - mode: 755
+        - require:
+            - elife-xpub-database-available
+
+    cmd.run:
+        - name: /usr/local/bin/setup-database.sh
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - require:
-            - elife-xpub-database-available
+            - file: elife-xpub-database-setup
         - require_in:
             - cmd: elife-xpub-docker-compose
 {% endif %}

--- a/salt/elife-xpub/scripts/setup-database.sh
+++ b/salt/elife-xpub/scripts/setup-database.sh
@@ -6,6 +6,11 @@ DB_CREATED_COMMAND="psql -c \"SELECT 'public.entities'::regclass\""
 DB_ENV="-e PGHOST=${PGHOST} -e PGPORT=${PGPORT} -e PGUSER=${PGUSER} -e PGDATABASE=${PGDATABASE} -e PGPASSWORD=${PGPASSWORD}"
 SETUP_ARGS="--username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 
+if [ ! -z "${FORCE}" ]; then
+    ${DC_COMMAND} run --rm app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS} --clobber"
+    exit
+fi
+
 if ! ${DC_COMMAND} run --rm ${DB_ENV} postgres /bin/bash -c "${DB_CREATED_COMMAND}"
 then
     ${DC_COMMAND} run --rm app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS}"


### PR DESCRIPTION
Stores the script on instances and allows to run it with an additional environment variable to clean up the database.

This allows `end2end` to be cleaned daily and other testing environments to be easily cleaned on demand, too.