### PR TITLE
Add postgresql chart as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 salt/top.sls
 helm/elife-xpub-*.tgz
+helm/elife-xpub/charts/*

--- a/helm/elife-xpub/requirements.lock
+++ b/helm/elife-xpub/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.4.0
+digest: sha256:6887311e5f436260a880207af94ef2e7b270f46e19d25d9ae8abc83da159477c
+generated: 2018-11-12T16:34:47.382707916Z

--- a/helm/elife-xpub/requirements.yaml
+++ b/helm/elife-xpub/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: "postgresql"
+  version: "2.4.0"
+  repository: "https://kubernetes-charts.storage.googleapis.com/"

--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -32,6 +32,15 @@ spec:
             value: production
           - name: PUBSWEET_SECRET
             value: example-secret
+            # `elife-xpub--test-postgresql` is the service name
+          - name: PGHOST
+            value: "{{ .Release.Name }}-postgresql"
+          - name: PGDATABASE
+            value: "{{ .Values.postgresql.postgresqlDatabase }}"
+          - name: PGUSER
+            value: "{{ .Values.postgresql.postgresqlUsername }}"
+          - name: PGPASSWORD
+            value: "{{ .Values.postgresql.postgresqlPassword }}"
           command: ["node", "app"]
           ports:
             - name: http

--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -23,6 +23,24 @@ spec:
         app.kubernetes.io/component: app
         app.kubernetes.io/part-of: {{ include "elife-xpub.name" . }}
     spec:
+      initContainers:
+        - name: {{ .Chart.Name }}-setupdb
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: NODE_ENV
+            value: production
+          - name: PUBSWEET_SECRET
+            value: example-secret
+          - name: PGHOST
+            value: "{{ .Release.Name }}-postgresql"
+          - name: PGDATABASE
+            value: "{{ .Values.postgresql.postgresqlDatabase }}"
+          - name: PGUSER
+            value: "{{ .Values.postgresql.postgresqlUsername }}"
+          - name: PGPASSWORD
+            value: "{{ .Values.postgresql.postgresqlPassword }}"
+          command: ["/bin/bash", "-c", "npx pubsweet setupdb --username=pubsweet --password=pubsweet --email=fake@example.com --clobber"]
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -5,3 +5,16 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+
+##
+## Postgresql chart configuration
+##
+postgresql:
+  image:
+    # TODO: use 10.4 if changing repository from default bitnami/postgresql
+    tag: "10.5.0"
+  persistence:
+    enabled: false
+  postgresqlDatabase: test
+  postgresqlUsername: test
+  postgresqlPassword: pw

--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: xpub/xpub-elife
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
- Add `stable/postgresql` chart as dependency
- Configure postgresql chart for `ci`: standard test credentials, closest Postgres version, disabled persistence
- Add `initContainer` for setup of database
- Change default `imagePullPolicy` for better performance