### PR TITLE
Change image used by Helm chart

### DIFF
--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: xpub/xpub-elife
+  repository: elifesciences/elife-xpub
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
We have been using the one that comes from Gitlab CI, but since Jenkins is faster it has to use its own or the review environment will break (possibly temporarily) for the lack of the pushed image.