### PR TITLE
Run migrations after deploy

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -126,7 +126,7 @@ elife-xpub-docker-compose:
 
 elife-xpub-database-migrations:
     cmd.run:
-        - name: {{ docker_compose }} exec -T app /bin/bash -c "npx pubsweet migrate"
+        - name: {{ docker_compose }} exec -T app npx pubsweet migrate
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - require:

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -124,12 +124,21 @@ elife-xpub-docker-compose:
         - require:
             - elife-xpub-repository
 
+elife-xpub-database-migrations:
+    cmd.run:
+        - name: {{ docker_compose }} exec app /bin/bash -c "npx pubsweet migrate"
+        - user: {{ pillar.elife.deploy_user.username }}
+        - cwd: /srv/elife-xpub
+        - require:
+            - elife-xpub-docker-compose
+
 elife-xpub-service-ready:
     cmd.run:
         - name: docker wait xpub_bootstrap_1
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - elife-xpub-docker-compose
+            - elife-xpub-database-migrations
 
 elife-xpub-nginx-vhost:
     file.managed:

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -126,7 +126,7 @@ elife-xpub-docker-compose:
 
 elife-xpub-database-migrations:
     cmd.run:
-        - name: {{ docker_compose }} exec app /bin/bash -c "npx pubsweet migrate"
+        - name: {{ docker_compose }} exec -T app /bin/bash -c "npx pubsweet migrate"
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - require:


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1102

Sample
```
    elife-xpub--vagrant: ----------
    elife-xpub--vagrant:           ID: elife-xpub-database-migrations
    elife-xpub--vagrant:     Function: cmd.run
    elife-xpub--vagrant:         Name: docker-compose -f docker-compose.yml -f docker-compose.formula.yml exec -T app npx pubsweet migrate
    elife-xpub--vagrant:       Result: True
    elife-xpub--vagrant:      Comment: Command "docker-compose -f docker-compose.yml -f docker-compose.formula.yml exec -T app npx pubsweet migrate" run
    elife-xpub--vagrant:      Started: 14:52:05.839156
    elife-xpub--vagrant:     Duration: 3405.124 ms
    elife-xpub--vagrant:      Changes:
    elife-xpub--vagrant:               ----------
    elife-xpub--vagrant:               pid:
    elife-xpub--vagrant:                   15718
    elife-xpub--vagrant:               retcode:
    elife-xpub--vagrant:                   0
    elife-xpub--vagrant:               stderr:
    elife-xpub--vagrant:               stdout:
```