### PR TITLE
Do not create a custom Postgres user in the Helm chart

### DIFF
--- a/helm/elife-xpub/templates/deployment.yaml
+++ b/helm/elife-xpub/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - name: PGDATABASE
             value: "{{ .Values.postgresql.postgresqlDatabase }}"
           - name: PGUSER
-            value: "{{ .Values.postgresql.postgresqlUsername }}"
+            value: "postgres"
           - name: PGPASSWORD
             value: "{{ .Values.postgresql.postgresqlPassword }}"
           command: ["/bin/bash", "-c", "npx pubsweet setupdb --username=pubsweet --password=pubsweet --email=fake@example.com --clobber"]
@@ -58,7 +58,7 @@ spec:
           - name: PGDATABASE
             value: "{{ .Values.postgresql.postgresqlDatabase }}"
           - name: PGUSER
-            value: "{{ .Values.postgresql.postgresqlUsername }}"
+            value: "postgres"
           - name: PGPASSWORD
             value: "{{ .Values.postgresql.postgresqlPassword }}"
           command: ["node", "app"]

--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 ##
 postgresql:
   image:
-    # TODO: use 10.4 if changing repository from default bitnami/postgresql
+    # should be 10.4 but it's the closest we have from bitnami/postgresql
     tag: "10.5.0"
   persistence:
     enabled: false

--- a/helm/elife-xpub/values.yaml
+++ b/helm/elife-xpub/values.yaml
@@ -16,5 +16,4 @@ postgresql:
   persistence:
     enabled: false
   postgresqlDatabase: test
-  postgresqlUsername: test
   postgresqlPassword: pw


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1226

According to https://hub.docker.com/r/bitnami/postgresql/ it's not mandatory to create a custom Postgres user, which will have permissions limited to the specific PGDATABASE that has been created.

Hence we end up with only one (super)user existing:

```
$ kubectl exec -it elife-xpub--postgresuser-postgresql-0 bash
I have no name!@elife-xpub--postgresuser-postgresql-0:/$ 
I have no name!@elife-xpub--postgresuser-postgresql-0:/$ PGDATABASE=test PGPASSWORD=pw PGUSER=postgres psql                                                               
psql (10.5)
Type "help" for help.

test=# \du
                                   List of roles
 Role name |                         Attributes                         | Member of 
-----------+------------------------------------------------------------+-----------
 postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
```

This is fine for the scope of this chart, which is to create dynamic testing environments.