### PR TITLE
Add dump and restore scripts

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -119,6 +119,24 @@ elife-xpub-database-setup:
             - file: elife-xpub-database-setup
         - require_in:
             - cmd: elife-xpub-docker-compose
+
+elife-database-scripts-dump:
+    file.managed:
+        - name: /usr/local/bin/dump-database.sh
+        - source: salt://elife-xpub/scripts/dump-database.sh
+        - template: jinja
+        - mode: 755
+        - require:
+            - elife-xpub-database-setup
+
+elife-database-scripts-restore:
+    file.managed:
+        - name: /usr/local/bin/restore-database.sh
+        - source: salt://elife-xpub/scripts/restore-database.sh
+        - template: jinja
+        - mode: 755
+        - require:
+            - elife-xpub-database-setup
 {% endif %}
 
 elife-xpub-docker-compose:

--- a/salt/elife-xpub/scripts/dump-database.sh
+++ b/salt/elife-xpub/scripts/dump-database.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -lt 1 ]; then
+    echo "Dumps a Postgres database into a 'directory'-format dump"
+    echo "Usage: ./dump-database.sh FILE [HOST] [PORT]"
+    echo "Example: ./dump-database.sh /ext/tmp/mydump elife-xpub-staging-restore-test.cxyopn44uqbl.us-east-1.rds.amazonaws.com 5432"
+    echo "FILE must use an absolute path (starting with /)"
+    exit 1
+fi
+
+file="$1"
+host="${2:-$PGHOST}"
+port="${3:-$PGPORT}"
+
+docker run \
+    -e PGHOST="$host" \
+    -e PGPORT="$port" \
+    -e PGUSER \
+    -e PGPASSWORD \
+    -e PGDATABASE \
+    -v "$file:$file" \
+    postgres:10 \
+    pg_dump -Fd -f "$file"

--- a/salt/elife-xpub/scripts/restore-database.sh
+++ b/salt/elife-xpub/scripts/restore-database.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -lt 1 ]; then
+    echo "Restores the Postgres database from a 'directory'-format dump"
+    echo "Usage: ./restore-database.sh FILE"
+    echo "Example: ./restore-database.sh /ext/tmp/mydump"
+    echo "FILE must use an absolute path (starting with /)"
+    exit 1
+fi
+
+file="$1"
+host="${2:-$PGHOST}"
+port="${3:-$PGPORT}"
+
+docker run \
+    -e PGHOST="$host" \
+    -e PGPORT="$port" \
+    -e PGUSER \
+    -e PGPASSWORD \
+    -v "$file:$file" \
+    postgres:10 \
+    pg_restore -c -d "$PGDATABASE" -Fd "$file"


### PR DESCRIPTION
Tested in Vagrant with the local `postgres` container, but code derived from exploration in `staging` and RDS:

```
[elife@elife-xpub--vagrant:~]$ dump-database.sh /home/elife/my-dump 192.168.33.44
[elife@elife-xpub--vagrant:~]$ restore-database.sh /home/elife/my-dump/ 192.168.33.44
```

The host argument is optional. The common use case would be to dump a separate RDS node that has been started from a RDS snapshot (a full server backup), and then restore it onto the current environment.

It is not possible to restore a RDS snapshot directly into the current environment due to CloudFormation (and our Salt formulas) limitations, as that would result in a new server and hostname to substitute to the current one and to configure the application with.