### PR TITLE
Integrate nginx-error-pages

### DIFF
--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -33,4 +33,6 @@ server {
 
     access_log /var/log/nginx/xpub.access.log combined_with_time;
     error_log /var/log/nginx/xpub.error.log;
+
+    include /etc/nginx/traits.d/error-pages.conf;
 }

--- a/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
+++ b/salt/elife-xpub/config/etc-nginx-sites-enabled-xpub.conf
@@ -23,6 +23,12 @@ server {
         proxy_buffering off;
     }
 
+    location = /ping-elb {
+        add_header Cache-Control "must-revalidate, no-cache, no-store, private";
+        add_header Content-Type "text/plain; charset=UTF-8";
+        return 200 "pong";
+    }
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -174,6 +174,7 @@ elife-xpub-nginx-vhost:
         - require:
             - nginx-config
             - elife-xpub-service-ready
+            - nginx-error-pages
         - listen_in:
             - service: nginx-server-service
 

--- a/salt/example.top
+++ b/salt/example.top
@@ -4,6 +4,7 @@ base:
         - elife.external-volume
         - elife.docker
         - elife.nginx
+        - elife.nginx-error-pages
         - elife.aws-cli
         - elife.aws-credentials
         - elife-xpub


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1409

https://github.com/elifesciences/error-pages/ is a project featuring custom error pages that nginx can serve if the application is off.

If the container is turned off, nginx will serve a Kaboom for example:
<img src="https://screenshotscdn.firefoxusercontent.com/images/24ee7611-5004-46f1-93c7-b561e8be8a66.png" />
(tested in Vagrant)

The ELB should be switched to use `/ping-elb` so that it doesn't cut off the all instances and show a blank page instead.