### PR TITLE
Introduce 5-minute timeout on application bootstrap

### DIFF
--- a/salt/elife-xpub/init.sls
+++ b/salt/elife-xpub/init.sls
@@ -172,7 +172,7 @@ elife-xpub-service-ready:
         - name: |
             docker-wait-healthy xpub_grobid_1
             docker-wait-healthy xpub_sciencebeam_1
-            docker wait xpub_bootstrap_1
+            timeout 300 docker wait xpub_bootstrap_1
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - elife-xpub-docker-compose


### PR DESCRIPTION
https://alfred.elifesciences.org/job/test-elife-xpub/893/ were waiting on this container to correctly exit to go on with the deployment, but got killed due to the 2-hour build timeout since the container was always restarting and never stopped.

Whatever the reason, it is more desirable for just this step to timeout rather than the entire build; then the failure is caught and (in the case of the `end2end` environment) a rollback to the last green version is performed.