### PR TITLE
Replace the clobber command with a clean then migrate. 

### DIFF
--- a/salt/elife-xpub/drop-database.sls
+++ b/salt/elife-xpub/drop-database.sls
@@ -1,0 +1,17 @@
+# drops and recreates the database on every run
+# do not use in real environments!
+
+{% if salt['elife.cfg']('project.node', 1) == 1 %}
+elife-xpub-database-drop:
+    cmd.run:
+        - name: |
+            /usr/local/bin/wait-database.sh
+            /usr/local/bin/setup-database.sh
+        - user: {{ pillar.elife.deploy_user.username }}
+        - cwd: /srv/elife-xpub
+        - env:
+            - DROP: 1
+            - TIMEOUT: 30
+        - require:
+            - elife-xpub-database-setup
+{% endif %}

--- a/salt/elife-xpub/drop-database.sls
+++ b/salt/elife-xpub/drop-database.sls
@@ -4,9 +4,7 @@
 {% if salt['elife.cfg']('project.node', 1) == 1 %}
 elife-xpub-database-drop:
     cmd.run:
-        - name: |
-            /usr/local/bin/wait-database.sh
-            /usr/local/bin/setup-database.sh
+        - name: /usr/local/bin/setup-database.sh
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /srv/elife-xpub
         - env:

--- a/salt/elife-xpub/scripts/setup-database.sh
+++ b/salt/elife-xpub/scripts/setup-database.sh
@@ -15,5 +15,5 @@ if [ ! -z "${DROP}" ]; then
     ${dc} run --rm ${db_env} postgres /bin/bash -c "${recreate}"
 fi
 
-# Always run the migrate to ensure the database has the correct schema
+echo Always run the migrate to ensure the database has the correct schema
 ${dc} run --rm app /bin/bash -c "npx pubsweet migrate"

--- a/salt/elife-xpub/scripts/setup-database.sh
+++ b/salt/elife-xpub/scripts/setup-database.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 set -e
 
-DC_COMMAND="docker-compose -f docker-compose.yml -f docker-compose.formula.yml"
-DB_CREATED_COMMAND="psql -c \"SELECT 'public.entities'::regclass\""
-DB_ENV="-e PGHOST=${PGHOST} -e PGPORT=${PGPORT} -e PGUSER=${PGUSER} -e PGDATABASE=${PGDATABASE} -e PGPASSWORD=${PGPASSWORD}"
-SETUP_ARGS="--username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
+dc="docker-compose -f docker-compose.yml -f docker-compose.formula.yml"
+db_env="-e PGHOST=${PGHOST} -e PGPORT=${PGPORT} -e PGUSER=${PGUSER} -e PGDATABASE=${PGDATABASE} -e PGPASSWORD=${PGPASSWORD}"
+recreate="dropdb ${PGDATABASE} && createdb ${PGDATABASE}"
+
+# Removing setting up a user (via clobber) in PubSweet as at the moment this is no longer necessary
+# This may be re-instated after the work to upgrade to the latest PubSweet version.
+# Ref: elifesciences/elife-xpub/issues/1920
+#
+# SETUP_ARGS="--username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 
 if [ ! -z "${DROP}" ]; then
-    ${DC_COMMAND} run --rm app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS} --clobber"
-    exit
+    ${dc} run --rm ${db_env} postgres /bin/bash -c "${recreate}"
 fi
 
-if ! ${DC_COMMAND} run --rm ${DB_ENV} postgres /bin/bash -c "${DB_CREATED_COMMAND}"
-then
-    ${DC_COMMAND} run --rm app /bin/bash -c "npx pubsweet setupdb ${SETUP_ARGS}"
-else
-    echo "Database is already present at ${PGHOST}:${PGPORT}"
-fi
+# Always run the migrate to ensure the database has the correct schema
+${dc} run --rm app /bin/bash -c "npx pubsweet migrate"

--- a/salt/elife-xpub/scripts/setup-database.sh
+++ b/salt/elife-xpub/scripts/setup-database.sh
@@ -2,6 +2,7 @@
 set -e
 
 dc="docker-compose -f docker-compose.yml -f docker-compose.formula.yml"
+clean_migrate_command="scripts/clean-migrate-database.js"
 db_env="-e PGHOST=${PGHOST} -e PGPORT=${PGPORT} -e PGUSER=${PGUSER} -e PGDATABASE=${PGDATABASE} -e PGPASSWORD=${PGPASSWORD}"
 recreate="dropdb ${PGDATABASE} && createdb ${PGDATABASE}"
 
@@ -12,8 +13,9 @@ recreate="dropdb ${PGDATABASE} && createdb ${PGDATABASE}"
 # SETUP_ARGS="--username={{ pillar.elife_xpub.database.user }} --password={{ pillar.elife_xpub.database.password }} --email={{ pillar.elife_xpub.database.email }}"
 
 if [ ! -z "${DROP}" ]; then
-    ${dc} run --rm ${db_env} postgres /bin/bash -c "${recreate}"
+  ${dc} run --rm app /bin/bash -c "${clean_migrate_command}"
+else
+  echo Always run the migrate to ensure the database has the correct schema
+  ${dc} run --rm app /bin/bash -c "npx pubsweet migrate"
 fi
 
-echo Always run the migrate to ensure the database has the correct schema
-${dc} run --rm app /bin/bash -c "npx pubsweet migrate"

--- a/salt/example-drop-database.top
+++ b/salt/example-drop-database.top
@@ -1,0 +1,12 @@
+# tests dropping and recreation of the database
+
+base:
+    '*':
+        - elife
+        - elife.external-volume
+        - elife.docker
+        - elife.nginx
+        - elife.aws-cli
+        - elife.aws-credentials
+        - elife-xpub
+        - elife-xpub.drop-database


### PR DESCRIPTION
Within xPub we no longer use the "user" table within the database as we use SSO with the journal. 

So delegate to xpub the clean then migrate function via a new script.
or... if we are not dropping the database run the pubsweet migrate command.